### PR TITLE
Fix/change return validation

### DIFF
--- a/backend/controllers/posController.js
+++ b/backend/controllers/posController.js
@@ -73,6 +73,14 @@ export const createInvoice = async (req, res) => {
     // Handle overpayment and change return
     const changeOwed = Math.max(0, paidAmount - totalAmount);
     const changeReturned = parseFloat(req.body.changeReturned) || 0;
+
+    // CRITICAL VALIDATION: Prevent Change Returned from exceeding Change Owed
+    if (changeReturned > changeOwed) {
+      return res.status(400).json({
+        message: "You are returning more amount than required. Please correct the change returned."
+      });
+    }
+
     const changeNotReturned = Math.max(0, changeOwed - changeReturned);
 
     // Cap paidAmount at totalAmount (don't record overpayment)

--- a/frontend/src/pages/POS.jsx
+++ b/frontend/src/pages/POS.jsx
@@ -466,6 +466,17 @@ const POS = () => {
       return;
     }
 
+    // CRITICAL VALIDATION: Prevent Change Returned from exceeding Change to Return
+    if (paid > total) {
+      const changeRequired = paid - total;
+      const changeReturned = parseFloat(activeTab.changeReturned) || 0;
+
+      if (changeReturned > changeRequired) {
+        alert('You are returning more amount than required. Please correct the change returned.');
+        return;
+      }
+    }
+
     // Check if walk-in customer is trying to take due
     if (!activeTab.customer && paid < total) {
       alert('Walk-in customers must pay full amount. Please add customer details to allow credit.');


### PR DESCRIPTION
## Summary

Blocked sale completion when the manually entered **Change Returned** amount exceeds the system-calculated **Change to Return**. This prevents incorrect cash handling and accounting inconsistencies by enforcing strict validation before completing a sale.

---

## Linked Issue (Required)

Closes #51 

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Enhancement
* [ ] Refactor
* [ ] Documentation
* [ ] Chore

---

## Changes Made

* Added validation to block sale completion when `Change Returned > Change to Return`
* Displayed a blocking error popup with a clear user message when validation fails
* Enforced backend-side validation to prevent bypassing frontend checks

---

## How to Test

1. Add items to the cart and proceed to billing.
2. Enter an Amount Paid greater than the total bill.
3. Manually enter a Change Returned value greater than the auto-calculated Change to Return.
4. Click **Complete Sale** and verify the sale is blocked with an error popup.
5. Correct the Change Returned value and verify the sale completes successfully.

---

## CI Status

* [x] All GitHub Actions checks are passing

---

## Screenshots / Logs (if applicable)

<img width="1919" height="890" alt="image" src="https://github.com/user-attachments/assets/aa7045e1-a5d1-4c4a-8d18-e7c00aeddee5" />

---

## Checklist

* [x] Issue is linked and relevant
* [x] Code builds and runs locally
* [x] Self-review completed
* [x] No unused code, logs, or commented-out blocks
* [x] Tests added or updated (if applicable)
* [x] Docs updated (if applicable)