### PR TITLE
Bug: Fix/dashboard stats hardcoded 0 values

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -222,7 +222,7 @@ const Dashboard = () => {
               </div>
             </div>
             <p className="text-gray-600 dark:text-[rgb(var(--color-text-secondary))] text-xs font-semibold uppercase tracking-wide mb-1.5">Total Invoices</p>
-            <p className="text-3xl font-bold text-gray-900 dark:text-[rgb(var(--color-text))]">0</p>
+            <p className="text-3xl font-bold text-gray-900 dark:text-[rgb(var(--color-text))]">{dashboardStats?.totalInvoices || 0}</p>
           </div>
 
           {/* Total Revenue */}
@@ -245,7 +245,7 @@ const Dashboard = () => {
               </div>
             </div>
             <p className="text-gray-600 dark:text-[rgb(var(--color-text-secondary))] text-xs font-semibold uppercase tracking-wide mb-1.5">Total Revenue</p>
-            <p className="text-3xl font-bold text-gray-900 dark:text-[rgb(var(--color-text))]">₹0.00</p>
+            <p className="text-3xl font-bold text-gray-900 dark:text-[rgb(var(--color-text))]">₹{(dashboardStats?.totalRevenue || 0).toFixed(2)}</p>
           </div>
 
           {/* Total Expenses */}
@@ -362,7 +362,7 @@ const Dashboard = () => {
             <p className="text-gray-600 dark:text-[rgb(var(--color-text-secondary))] text-xs font-semibold uppercase tracking-wide mb-1.5">
               Pending Payments
             </p>
-            <p className="text-3xl font-bold text-gray-900 dark:text-[rgb(var(--color-text))]">0</p>
+            <p className="text-3xl font-bold text-gray-900 dark:text-[rgb(var(--color-text))]">₹{(dashboardStats?.totalOutstanding || 0).toFixed(2)}</p>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
Fixed an issue where dashboard metric cards were displaying hardcoded zero values.  
The dashboard now fetches real, aggregated invoice data from the backend to ensure accurate business insights.

## Linked Issue (Required)
Closes #58 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes Made
- Added `/api/reports/dashboard` API endpoint to aggregate invoice metrics
- Implemented backend logic to calculate:
  - Total Invoices
  - Total Revenue
  - Pending Payments (Outstanding)
- Updated dashboard to consume backend data instead of hardcoded values

## How to Test
1. Start the backend server.
2. Ensure invoice data exists in the database.
3. Open the dashboard and verify that all metric cards display correct, non-zero values.

## CI Status
- [] All GitHub Actions checks are passing

## Screenshots / Logs (if applicable)
<img width="1919" height="930" alt="image" src="https://github.com/user-attachments/assets/eab66524-ec8c-4266-bb8c-a84dd5bc9e82" />


## Checklist
- [x] Issue is linked and relevant
- [x] Code builds and runs locally
- [x] Self-review completed
- [x] No unused code, logs, or commented-out blocks
- [] Tests added or updated (if applicable)
- [] Docs updated (if applicable)
