### PR TITLE
feat: show customer pending due and credit during estimate creation

### DIFF
--- a/frontend/src/pages/sales/Estimate.jsx
+++ b/frontend/src/pages/sales/Estimate.jsx
@@ -50,10 +50,10 @@ const Estimate = () => {
         cart.map((cartItem) =>
           cartItem.itemId === item._id
             ? {
-              ...cartItem,
-              quantity: cartItem.quantity + 1,
-              total: (cartItem.quantity + 1) * cartItem.price,
-            }
+                ...cartItem,
+                quantity: cartItem.quantity + 1,
+                total: (cartItem.quantity + 1) * cartItem.price,
+              }
             : cartItem
         )
       );
@@ -81,10 +81,10 @@ const Estimate = () => {
       cart.map((cartItem) =>
         cartItem.itemId === itemId
           ? {
-            ...cartItem,
-            quantity: newQuantity,
-            total: newQuantity * cartItem.price,
-          }
+              ...cartItem,
+              quantity: newQuantity,
+              total: newQuantity * cartItem.price,
+            }
           : cartItem
       )
     );
@@ -271,6 +271,63 @@ const Estimate = () => {
                   >
                     Walk-in Customer (Click to select)
                   </button>
+                )}
+                {/* Credit Balance Display */}
+                {customer && customer.dues < 0 && (
+                  <div className="mt-3 p-3 bg-green-50 rounded-lg border border-green-200">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center space-x-2">
+                        <svg
+                          className="w-5 h-5 text-green-600"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                          />
+                        </svg>
+                        <span className="text-sm font-medium text-green-800">
+                          Available Credit
+                        </span>
+                      </div>
+                      <span className="text-lg font-bold text-green-600">
+                        ₹{Math.abs(customer.dues.toFixed(2))}
+                      </span>
+                    </div>
+                  </div>
+                )}
+
+                {/* Pending Dues Display */}
+                {customer && customer?.dues > 0 && (
+                  <div className="mt-3 p-3 bg-red-50 rounded-lg border border-red-200">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center space-x-2">
+                        <svg
+                          className="w-5 h-5 text-red-600"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                          />
+                        </svg>
+                        <span className="text-sm font-medium text-red-800">
+                          Pending Dues
+                        </span>
+                      </div>
+                      <span className="text-lg font-bold text-red-600">
+                        ₹{customer.dues.toFixed(2)}
+                      </span>
+                    </div>
+                  </div>
                 )}
               </div>
 


### PR DESCRIPTION
## Summary
<!-- Clearly explain WHAT changed and WHY. No vague statements. -->
This PR adds feature to display customer dues or available credits information, while creating estimates in real time.
This give addition information of customer before finalizing estimate

## Linked Issue (Required)
<!-- PRs without an issue link should not be merged -->
Closes #86

## Type of Change
<!-- Select one primary type -->
- [ ] Bug fix
- [X] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes Made
<!-- Bullet list of key changes -->
- Added feature to display customer dues or available credit (if present), while creating estimate.
- 

## How to Test
<!-- Exact steps so anyone on the team can verify -->
1. Under the Sales Navbar, click 'Estimate / Profoma' link
2. In the Customer field, select an customer
3. if the customer has any dues or credit available, it will be show below customer

## CI Status
<!-- CI must be green before merge -->
- [ ] All GitHub Actions checks are passing

## Screenshots / Logs (if applicable)
<!-- Required for UI or behavior changes -->
<img width="1920" height="982" alt="Screenshot From 2025-12-30 16-56-17" src="https://github.com/user-attachments/assets/6bd2cec1-2aac-46f9-811a-052489b14e51" />
<img width="1920" height="982" alt="Screenshot From 2025-12-30 17-20-18" src="https://github.com/user-attachments/assets/7c4e1620-85fb-42c5-a1b6-05bba5c39b8e" />


## Checklist
- [X] Issue is linked and relevant
- [X] Code builds and runs locally
- [X] Self-review completed
- [X] No unused code, logs, or commented-out blocks
- [ ] Tests added or updated (if applicable)
- [ ] Docs updated (if applicable)
