### PR TITLE
Fixed dark mode issue in returned item

### DIFF
--- a/frontend/src/pages/sales/ReturnedItems.jsx
+++ b/frontend/src/pages/sales/ReturnedItems.jsx
@@ -196,7 +196,7 @@ const ReturnedItems = () => {
                             <tbody className="bg-card divide-y divide-gray-200">
                                 {filteredReturns.map((returnItem) => (
                                     <>
-                                        <tr key={returnItem._id} className="hover:bg-gray-50">
+                                        <tr key={returnItem._id} className="hover:bg-surface">
                                             <td className="px-6 py-4 whitespace-nowrap">
                                                 <button
                                                     onClick={() => toggleRowExpansion(returnItem._id)}


### PR DESCRIPTION
## Summary
Fixed the hover state visibility issue in the Returned Items table in dark mode. The table row hover background was using hover:bg-gray-50 (a light gray), which made the text invisible when hovering in dark mode since the text is also light-colored. Changed to hover:bg-surface which is theme-aware and provides appropriate contrast in both light and dark modes.

## Linked Issue (Required)
<!-- PRs without an issue link should not be merged -->
Closes #98 

## Type of Change
<!-- Select one primary type -->
- [ ] Bug fix

## Changes Made
- Changed table row hover style from hover:bg-gray-50 to hover:bg-surface in 
ReturnedItems.jsx
- This ensures the hover state uses the theme's surface color, maintaining text visibility in both light and dark modes

## How to Test
1. Run the frontend application
2. Navigate to Sales → Returned Items
3. Switch to dark mode (if not already)
4. Hover over any row in the returns table
5. Verify the text remains visible and readable during hover

## CI Status
<!-- CI must be green before merge -->
- [ ] All GitHub Actions checks are passing

## Screenshots / Logs (if applicable)
<img width="1440" height="779" alt="Screenshot 2025-12-30 at 10 44 19 PM" src="https://github.com/user-attachments/assets/b6d4338c-400d-49f9-bdd3-82714f55380a" />


## Checklist
- [ ] Code builds and runs locally
- [ ] Self-review completed
- [ ] No unused code, logs, or commented-out blocks