### PR TITLE
Fixed visibility issue in dark mode in return page

### DIFF
--- a/frontend/src/pages/sales/Return.jsx
+++ b/frontend/src/pages/sales/Return.jsx
@@ -324,7 +324,7 @@ const Return = () => {
               Select Invoice
             </h2>
             {formData.selectedInvoice ? (
-              <div className="p-4 bg-indigo-50 rounded-lg">
+              <div className="p-4 bg-indigo-50 dark:bg-indigo-900/30 rounded-lg">
                 <div className="flex items-center justify-between">
                   <div>
                     <p className="font-medium text-main">
@@ -451,7 +451,7 @@ const Return = () => {
                                 )
                               )
                             }
-                            className="w-20 px-2 py-1 border rounded"
+                            className="w-20 px-2 py-1 border border-default rounded bg-card text-main focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
                             min="0"
                             max={item.remainingQty}
                           />
@@ -468,7 +468,7 @@ const Return = () => {
                               // Clear reason when condition changes to prevent invalid combinations
                               updateItem(index, "reason", "");
                             }}
-                            className="w-32 px-2 py-1 border rounded"
+                            className="w-32 px-2 py-1 border border-default rounded bg-card text-main focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
                           >
                             <option value="not_damaged">Not Damaged</option>
                             <option value="damaged">Damaged</option>
@@ -480,7 +480,7 @@ const Return = () => {
                             onChange={(e) =>
                               updateItem(index, "reason", e.target.value)
                             }
-                            className="w-40 px-2 py-1 border rounded"
+                            className="w-40 px-2 py-1 border border-default rounded bg-card text-main focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
                           >
                             <option value="">Select reason</option>
                             {getReasonsForCondition(item.condition).map(
@@ -542,7 +542,7 @@ const Return = () => {
                       setFormData({ ...formData, notes: e.target.value })
                     }
                     rows="3"
-                    className="w-full px-4 py-2 border rounded-lg"
+                    className="w-full px-4 py-2 border border-default rounded-lg bg-card text-main focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
                     placeholder="Add notes about the return..."
                   />
                 </div>
@@ -579,8 +579,8 @@ const Return = () => {
                 </span>
               </div>
             </div>
-            <div className="p-4 bg-yellow-50 border border-yellow-200 rounded-lg mb-6">
-              <p className="text-xs text-yellow-800">
+            <div className="p-4 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-700 rounded-lg mb-6">
+              <p className="text-xs text-yellow-800 dark:text-yellow-200">
                 <strong>Note:</strong> This amount will be credited to the
                 customer's account or refunded via the selected method.
               </p>
@@ -606,7 +606,7 @@ const Return = () => {
 
       {/* Invoice Selection Modal */}
       {showInvoiceModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50   dark:bg-gray-700 p-4">
+        <div className="fixed inset-0 bg-black/75 backdrop-blur-sm flex items-center justify-center z-50 p-4">
           <div className="bg-card rounded-xl shadow-xl max-w-4xl w-full max-h-[80vh] overflow-hidden">
             <div className="p-6 border-b">
               <div className="flex items-center justify-between mb-4">
@@ -637,7 +637,7 @@ const Return = () => {
                 placeholder="Search by invoice number or customer name..."
                 value={searchInvoice}
                 onChange={(e) => setSearchInvoice(e.target.value)}
-                className="w-full px-4 py-2 border rounded-lg"
+                className="w-full px-4 py-2 border border-default rounded-lg bg-card text-main placeholder:text-muted focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
               />
             </div>
             <div className="overflow-y-auto max-h-96 p-6">
@@ -651,7 +651,7 @@ const Return = () => {
                     <div
                       key={invoice._id}
                       onClick={() => handleInvoiceSelect(invoice)}
-                      className="p-4 border rounded-lg hover:bg-indigo-50 hover:border-indigo-500 cursor-pointer transition"
+                      className="p-4 border border-default rounded-lg hover:bg-surface hover:border-indigo-500 cursor-pointer transition"
                     >
                       <div className="flex items-center justify-between">
                         <div>


### PR DESCRIPTION
## Summary

Fixed multiple dark mode visibility and contrast issues on the **Return** page (`Return.jsx`). Several UI elements were unreadable or effectively invisible in dark mode due to light-only styles. Updated all affected components to use theme-aware utility classes so they render with correct contrast, hover states, and focus indicators in both light and dark modes.

This is a **bug fix**, not a cosmetic tweak — the page was functionally broken in dark mode.

---

## Linked Issue (Required)

Closes #97 

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Enhancement
* [ ] Refactor
* [ ] Documentation
* [ ] Chore

---

## Changes Made

* Fixed invoice selection modal backdrop by replacing `bg-opacity-50` with `bg-black/75 backdrop-blur-sm` to achieve consistent ~75% dimming in dark mode.
* Updated invoice list hover styles from `hover:bg-indigo-50` to `hover:bg-surface` for theme-aware contrast.
* Added dark mode–safe styles to all input fields (`bg-card text-main border-default`) with proper focus ring behavior.
* Updated Condition and Reason dropdowns to use theme-aware background, text, and border classes.
* Adjusted selected invoice highlight to use `dark:bg-indigo-900/30` for visibility without overpowering contrast.
* Fixed note section styling with explicit dark mode background, border, and text colors to maintain readability.

---

## How to Test

1. Run the frontend (`npm run dev`).
2. Navigate to **Sales → Return**.
3. Enable dark mode.
4. Click **Select Invoice** and verify the modal backdrop is properly dimmed (~75%) and content remains readable.
5. Hover over invoice rows and confirm text and background contrast are correct.
6. Select an invoice and interact with:

   * Return Qty inputs
   * Condition dropdown
   * Reason dropdown
   * Note section
7. Verify all elements are visible and readable in normal, hover, and focus states.

---

## CI Status

* [x] All GitHub Actions checks are passing

---

## Screenshots / Logs (if applicable)
<img width="1439" height="776" alt="Screenshot 2025-12-30 at 11 03 33 PM" src="https://github.com/user-attachments/assets/2583b8cb-1dd9-477c-b06f-bf01f5b0354a" />
<img width="1440" height="777" alt="Screenshot 2025-12-30 at 11 03 55 PM" src="https://github.com/user-attachments/assets/6cf04e98-db44-4cd3-8ad5-0cd170a4b87c" />

Attached (dark mode before/after for modal, invoice list, inputs, and note section).

---

## Checklist

* [x] Issue is linked and relevant
* [x] Code builds and runs locally
* [x] Self-review completed
* [x] No unused code, logs, or commented-out blocks
* [ ] Tests added or updated (if applicable) — **not applicable (UI styling fix only)**
* [ ] Docs updated (if applicable) — **not applicable**

---