### PR TITLE
Fix/returned items UI visibility and layout

### DIFF
--- a/frontend/src/pages/sales/ReturnedItems.jsx
+++ b/frontend/src/pages/sales/ReturnedItems.jsx
@@ -12,6 +12,8 @@ const ReturnedItems = () => {
     const [statusFilter, setStatusFilter] = useState('all');
     const [refundMethodFilter, setRefundMethodFilter] = useState('all');
     const [expandedRows, setExpandedRows] = useState(new Set());
+    const [currentPage, setCurrentPage] = useState(1);
+    const itemsPerPage = 20;
 
     // Get token from user object in localStorage
     const user = JSON.parse(localStorage.getItem('user'));
@@ -21,6 +23,10 @@ const ReturnedItems = () => {
     useEffect(() => {
         fetchReturns();
     }, []);
+
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [searchTerm, statusFilter, refundMethodFilter]);
 
     const fetchReturns = async () => {
         try {
@@ -89,6 +95,12 @@ const ReturnedItems = () => {
         return matchesSearch && matchesStatus && matchesRefundMethod;
     });
 
+    // Pagination calculations
+    const totalPages = Math.ceil(filteredReturns.length / itemsPerPage);
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    const endIndex = startIndex + itemsPerPage;
+    const paginatedReturns = filteredReturns.slice(startIndex, endIndex);
+
     if (loading) {
         return (
             <Layout>
@@ -114,6 +126,34 @@ const ReturnedItems = () => {
                     </button>
                 ]}
             />
+
+            {/* Summary Stats - Moved to Top */}
+            {filteredReturns.length > 0 && (
+                <div className="mb-6 grid grid-cols-1 md:grid-cols-4 gap-4">
+                    <div className="bg-card rounded-lg shadow-sm p-4">
+                        <p className="text-sm text-secondary">Total Returns</p>
+                        <p className="text-2xl font-bold text-main">{filteredReturns.length}</p>
+                    </div>
+                    <div className="bg-card rounded-lg shadow-sm p-4">
+                        <p className="text-sm text-secondary">Total Amount</p>
+                        <p className="text-2xl font-bold text-red-600">
+                            ₹{filteredReturns.reduce((sum, ret) => sum + ret.totalReturnAmount, 0).toFixed(2)}
+                        </p>
+                    </div>
+                    <div className="bg-card rounded-lg shadow-sm p-4">
+                        <p className="text-sm text-secondary">Full Returns</p>
+                        <p className="text-2xl font-bold text-purple-600">
+                            {filteredReturns.filter(ret => ret.returnType === 'full').length}
+                        </p>
+                    </div>
+                    <div className="bg-card rounded-lg shadow-sm p-4">
+                        <p className="text-sm text-secondary">Partial Returns</p>
+                        <p className="text-2xl font-bold text-blue-600">
+                            {filteredReturns.filter(ret => ret.returnType === 'partial').length}
+                        </p>
+                    </div>
+                </div>
+            )}
 
             {/* Filters */}
             <div className="bg-card rounded-xl shadow-sm p-6 mb-6">
@@ -177,176 +217,198 @@ const ReturnedItems = () => {
                         </div>
                     </div>
                 ) : (
-                    <div className="overflow-x-auto">
-                        <table className="w-full">
-                            <thead className="bg-surface border-b">
-                                <tr>
-                                    <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Return ID</th>
-                                    <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Date</th>
-                                    <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Invoice</th>
-                                    <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Customer</th>
-                                    <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Type</th>
-                                    <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Items</th>
-                                    <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Amount</th>
-                                    <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Refund Method</th>
-                                    <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Status</th>
-                                    <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Actions</th>
-                                </tr>
-                            </thead>
-                            <tbody className="bg-card divide-y divide-gray-200">
-                                {filteredReturns.map((returnItem) => (
-                                    <>
-                                        <tr key={returnItem._id} className="hover:bg-surface">
-                                            <td className="px-6 py-4 whitespace-nowrap">
-                                                <button
-                                                    onClick={() => toggleRowExpansion(returnItem._id)}
-                                                    className="flex items-center text-indigo-600 hover:text-indigo-900 font-medium"
-                                                >
-                                                    <svg
-                                                        className={`w-4 h-4 mr-2 transition-transform ${expandedRows.has(returnItem._id) ? 'rotate-90' : ''}`}
-                                                        fill="none"
-                                                        stroke="currentColor"
-                                                        viewBox="0 0 24 24"
+                    <>
+                        <div className="overflow-x-auto">
+                            <table className="w-full">
+                                <thead className="bg-surface border-b">
+                                    <tr>
+                                        <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Return ID</th>
+                                        <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Date</th>
+                                        <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Invoice</th>
+                                        <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Customer</th>
+                                        <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Type</th>
+                                        <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Items</th>
+                                        <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Amount</th>
+                                        <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Refund Method</th>
+                                        <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Status</th>
+                                        <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody className="bg-card divide-y divide-gray-200">
+                                    {paginatedReturns.map((returnItem) => (
+                                        <>
+                                            <tr key={returnItem._id} className="hover:bg-surface">
+                                                <td className="px-6 py-4 whitespace-nowrap">
+                                                    <button
+                                                        onClick={() => toggleRowExpansion(returnItem._id)}
+                                                        className="flex items-center text-indigo-600 hover:text-indigo-900 font-medium"
                                                     >
-                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                                                    </svg>
-                                                    {returnItem.returnId}
-                                                </button>
-                                            </td>
-                                            <td className="px-6 py-4 whitespace-nowrap text-sm text-main">
-                                                {new Date(returnItem.returnDate).toLocaleDateString()}
-                                            </td>
-                                            <td className="px-6 py-4 whitespace-nowrap">
-                                                <button
-                                                    onClick={() => navigate(`/pos/invoice/${returnItem.invoice._id}`)}
-                                                    className="text-sm text-indigo-600 hover:text-indigo-900"
-                                                >
-                                                    {returnItem.invoice?.invoiceNo || 'N/A'}
-                                                </button>
-                                            </td>
-                                            <td className="px-6 py-4 whitespace-nowrap text-sm text-main">
-                                                {returnItem.customerName}
-                                            </td>
-                                            <td className="px-6 py-4 whitespace-nowrap">
-                                                <span className={`px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${returnItem.returnType === 'full' ? 'bg-purple-100 text-purple-800' : 'bg-blue-100 text-blue-800'
-                                                    }`}>
-                                                    {returnItem.returnType}
-                                                </span>
-                                            </td>
-                                            <td className="px-6 py-4 whitespace-nowrap text-sm text-main">
-                                                {returnItem.items.length}
-                                            </td>
-                                            <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-main">
-                                                ₹{returnItem.totalReturnAmount.toFixed(2)}
-                                            </td>
-                                            <td className="px-6 py-4 whitespace-nowrap text-sm text-main capitalize">
-                                                {returnItem.refundMethod.replace('_', ' ')}
-                                            </td>
-                                            <td className="px-6 py-4 whitespace-nowrap">
-                                                <span className={`px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${getStatusColor(returnItem.status)}`}>
-                                                    {returnItem.status}
-                                                </span>
-                                            </td>
-                                            <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                                                <button
-                                                    onClick={() => handleDelete(returnItem._id)}
-                                                    className="text-red-600 hover:text-red-900"
-                                                >
-                                                    Delete
-                                                </button>
-                                            </td>
-                                        </tr>
-                                        {expandedRows.has(returnItem._id) && (
-                                            <tr>
-                                                <td colSpan="10" className="px-6 py-4 bg-surface">
-                                                    <div className="space-y-4">
-                                                        <h4 className="font-medium text-main">Return Items Details</h4>
-                                                        <div className="overflow-x-auto">
-                                                            <table className="min-w-full divide-y divide-gray-200">
-                                                                <thead className="bg-surface">
-                                                                    <tr>
-                                                                        <th className="px-4 py-2 text-left text-xs font-medium text-muted uppercase">Product</th>
-                                                                        <th className="px-4 py-2 text-left text-xs font-medium text-muted uppercase">Original Qty</th>
-                                                                        <th className="px-4 py-2 text-left text-xs font-medium text-muted uppercase">Returned Qty</th>
-                                                                        <th className="px-4 py-2 text-left text-xs font-medium text-muted uppercase">Rate</th>
-                                                                        <th className="px-4 py-2 text-left text-xs font-medium text-muted uppercase">Condition</th>
-                                                                        <th className="px-4 py-2 text-left text-xs font-medium text-muted uppercase">Reason</th>
-                                                                        <th className="px-4 py-2 text-left text-xs font-medium text-muted uppercase">Inventory Adjusted</th>
-                                                                        <th className="px-4 py-2 text-left text-xs font-medium text-muted uppercase">Line Total</th>
-                                                                    </tr>
-                                                                </thead>
-                                                                <tbody className="bg-card divide-y divide-gray-200">
-                                                                    {returnItem.items.map((item, idx) => (
-                                                                        <tr key={idx}>
-                                                                            <td className="px-4 py-2 text-sm text-main">{item.productName}</td>
-                                                                            <td className="px-4 py-2 text-sm text-main">{item.originalQty}</td>
-                                                                            <td className="px-4 py-2 text-sm text-main">{item.returnedQty}</td>
-                                                                            <td className="px-4 py-2 text-sm text-main">₹{item.rate.toFixed(2)}</td>
-                                                                            <td className="px-4 py-2 text-sm">
-                                                                                <span className={`px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${item.condition === 'damaged' ? 'bg-red-100 text-red-800' : 'bg-green-100 text-green-800'
-                                                                                    }`}>
-                                                                                    {item.condition.replace('_', ' ')}
-                                                                                </span>
-                                                                            </td>
-                                                                            <td className="px-4 py-2 text-sm text-main">{item.reason}</td>
-                                                                            <td className="px-4 py-2 text-sm">
-                                                                                {item.inventoryAdjusted ? (
-                                                                                    <span className="text-green-600">✓ Yes</span>
-                                                                                ) : (
-                                                                                    <span className="text-muted">✗ No</span>
-                                                                                )}
-                                                                            </td>
-                                                                            <td className="px-4 py-2 text-sm font-medium text-main">₹{item.lineTotal.toFixed(2)}</td>
-                                                                        </tr>
-                                                                    ))}
-                                                                </tbody>
-                                                            </table>
-                                                        </div>
-                                                        {returnItem.notes && (
-                                                            <div className="mt-4">
-                                                                <h5 className="text-sm font-medium text-secondary">Notes:</h5>
-                                                                <p className="text-sm text-secondary mt-1">{returnItem.notes}</p>
-                                                            </div>
-                                                        )}
-                                                    </div>
+                                                        <svg
+                                                            className={`w-4 h-4 mr-2 transition-transform ${expandedRows.has(returnItem._id) ? 'rotate-90' : ''}`}
+                                                            fill="none"
+                                                            stroke="currentColor"
+                                                            viewBox="0 0 24 24"
+                                                        >
+                                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                                                        </svg>
+                                                        {returnItem.returnId}
+                                                    </button>
+                                                </td>
+                                                <td className="px-6 py-4 whitespace-nowrap text-sm text-main">
+                                                    {new Date(returnItem.returnDate).toLocaleDateString()}
+                                                </td>
+                                                <td className="px-6 py-4 whitespace-nowrap">
+                                                    <button
+                                                        onClick={() => navigate(`/pos/invoice/${returnItem.invoice._id}`)}
+                                                        className="text-sm text-indigo-600 hover:text-indigo-900"
+                                                    >
+                                                        {returnItem.invoice?.invoiceNo || 'N/A'}
+                                                    </button>
+                                                </td>
+                                                <td className="px-6 py-4 whitespace-nowrap text-sm text-main">
+                                                    {returnItem.customerName}
+                                                </td>
+                                                <td className="px-6 py-4 whitespace-nowrap">
+                                                    <span className={`px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${returnItem.returnType === 'full' ? 'bg-purple-100 text-purple-800' : 'bg-blue-100 text-blue-800'
+                                                        }`}>
+                                                        {returnItem.returnType}
+                                                    </span>
+                                                </td>
+                                                <td className="px-6 py-4 whitespace-nowrap text-sm text-main">
+                                                    {returnItem.items.length}
+                                                </td>
+                                                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-main">
+                                                    ₹{returnItem.totalReturnAmount.toFixed(2)}
+                                                </td>
+                                                <td className="px-6 py-4 whitespace-nowrap text-sm text-main capitalize">
+                                                    {returnItem.refundMethod.replace('_', ' ')}
+                                                </td>
+                                                <td className="px-6 py-4 whitespace-nowrap">
+                                                    <span className={`px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${getStatusColor(returnItem.status)}`}>
+                                                        {returnItem.status}
+                                                    </span>
+                                                </td>
+                                                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                                                    <button
+                                                        onClick={() => handleDelete(returnItem._id)}
+                                                        className="text-red-600 hover:text-red-900"
+                                                    >
+                                                        Delete
+                                                    </button>
                                                 </td>
                                             </tr>
-                                        )}
-                                    </>
-                                ))}
-                            </tbody>
-                        </table>
-                    </div>
+                                            {expandedRows.has(returnItem._id) && (
+                                                <tr>
+                                                    <td colSpan="10" className="px-6 py-4 bg-surface">
+                                                        <div className="space-y-4">
+                                                            <h4 className="font-medium text-main">Return Items Details</h4>
+                                                            <div className="overflow-x-auto">
+                                                                <table className="min-w-full divide-y divide-gray-200">
+                                                                    <thead className="bg-surface">
+                                                                        <tr>
+                                                                            <th className="px-4 py-2 text-left text-xs font-medium text-muted uppercase">Product</th>
+                                                                            <th className="px-4 py-2 text-left text-xs font-medium text-muted uppercase">Original Qty</th>
+                                                                            <th className="px-4 py-2 text-left text-xs font-medium text-muted uppercase">Returned Qty</th>
+                                                                            <th className="px-4 py-2 text-left text-xs font-medium text-muted uppercase">Rate</th>
+                                                                            <th className="px-4 py-2 text-left text-xs font-medium text-muted uppercase">Condition</th>
+                                                                            <th className="px-4 py-2 text-left text-xs font-medium text-muted uppercase">Reason</th>
+                                                                            <th className="px-4 py-2 text-left text-xs font-medium text-muted uppercase">Inventory Adjusted</th>
+                                                                            <th className="px-4 py-2 text-left text-xs font-medium text-muted uppercase">Line Total</th>
+                                                                        </tr>
+                                                                    </thead>
+                                                                    <tbody className="bg-card divide-y divide-gray-200">
+                                                                        {returnItem.items.map((item, idx) => (
+                                                                            <tr key={idx}>
+                                                                                <td className="px-4 py-2 text-sm text-main">{item.productName}</td>
+                                                                                <td className="px-4 py-2 text-sm text-main">{item.originalQty}</td>
+                                                                                <td className="px-4 py-2 text-sm text-main">{item.returnedQty}</td>
+                                                                                <td className="px-4 py-2 text-sm text-main">₹{item.rate.toFixed(2)}</td>
+                                                                                <td className="px-4 py-2 text-sm">
+                                                                                    <span className={`px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${item.condition === 'damaged' ? 'bg-red-100 text-red-800' : 'bg-green-100 text-green-800'
+                                                                                        }`}>
+                                                                                        {item.condition.replace('_', ' ')}
+                                                                                    </span>
+                                                                                </td>
+                                                                                <td className="px-4 py-2 text-sm text-main">{item.reason}</td>
+                                                                                <td className="px-4 py-2 text-sm">
+                                                                                    {item.inventoryAdjusted ? (
+                                                                                        <span className="text-green-600">✓ Yes</span>
+                                                                                    ) : (
+                                                                                        <span className="text-muted">✗ No</span>
+                                                                                    )}
+                                                                                </td>
+                                                                                <td className="px-4 py-2 text-sm font-medium text-main">₹{item.lineTotal.toFixed(2)}</td>
+                                                                            </tr>
+                                                                        ))}
+                                                                    </tbody>
+                                                                </table>
+                                                            </div>
+                                                            {returnItem.notes && (
+                                                                <div className="mt-4">
+                                                                    <h5 className="text-sm font-medium text-secondary">Notes:</h5>
+                                                                    <p className="text-sm text-secondary mt-1">{returnItem.notes}</p>
+                                                                </div>
+                                                            )}
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                            )}
+                                        </>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+
+                        {/* Pagination Controls */}
+                        {totalPages > 1 && (
+                            <div className="px-6 py-4 border-t border-gray-200 flex items-center justify-between">
+                                <div className="text-sm text-secondary">
+                                    Showing {startIndex + 1} to {Math.min(endIndex, filteredReturns.length)} of {filteredReturns.length} results
+                                </div>
+                                <div className="flex items-center gap-2">
+                                    <button
+                                        onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))}
+                                        disabled={currentPage === 1}
+                                        className="px-3 py-1 border rounded-md text-sm disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface"
+                                    >
+                                        Previous
+                                    </button>
+                                    {Array.from({ length: totalPages }, (_, i) => i + 1).map(page => {
+                                        if (
+                                            page === 1 ||
+                                            page === totalPages ||
+                                            (page >= currentPage - 1 && page <= currentPage + 1)
+                                        ) {
+                                            return (
+                                                <button
+                                                    key={page}
+                                                    onClick={() => setCurrentPage(page)}
+                                                    className={`px-3 py-1 border rounded-md text-sm ${currentPage === page
+                                                        ? 'bg-indigo-600 text-white border-indigo-600'
+                                                        : 'hover:bg-surface'
+                                                        }`}
+                                                >
+                                                    {page}
+                                                </button>
+                                            );
+                                        } else if (page === currentPage - 2 || page === currentPage + 2) {
+                                            return <span key={page} className="px-2">...</span>;
+                                        }
+                                        return null;
+                                    })}
+                                    <button
+                                        onClick={() => setCurrentPage(prev => Math.min(totalPages, prev + 1))}
+                                        disabled={currentPage === totalPages}
+                                        className="px-3 py-1 border rounded-md text-sm disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface"
+                                    >
+                                        Next
+                                    </button>
+                                </div>
+                            </div>
+                        )}
+                    </>
                 )}
             </div>
-
-            {/* Summary Stats */}
-            {filteredReturns.length > 0 && (
-                <div className="mt-6 grid grid-cols-1 md:grid-cols-4 gap-4">
-                    <div className="bg-card rounded-lg shadow-sm p-4">
-                        <p className="text-sm text-secondary">Total Returns</p>
-                        <p className="text-2xl font-bold text-main">{filteredReturns.length}</p>
-                    </div>
-                    <div className="bg-card rounded-lg shadow-sm p-4">
-                        <p className="text-sm text-secondary">Total Amount</p>
-                        <p className="text-2xl font-bold text-red-600">
-                            ₹{filteredReturns.reduce((sum, ret) => sum + ret.totalReturnAmount, 0).toFixed(2)}
-                        </p>
-                    </div>
-                    <div className="bg-card rounded-lg shadow-sm p-4">
-                        <p className="text-sm text-secondary">Full Returns</p>
-                        <p className="text-2xl font-bold text-purple-600">
-                            {filteredReturns.filter(ret => ret.returnType === 'full').length}
-                        </p>
-                    </div>
-                    <div className="bg-card rounded-lg shadow-sm p-4">
-                        <p className="text-sm text-secondary">Partial Returns</p>
-                        <p className="text-2xl font-bold text-blue-600">
-                            {filteredReturns.filter(ret => ret.returnType === 'partial').length}
-                        </p>
-                    </div>
-                </div>
-            )}
         </Layout>
     );
 };


### PR DESCRIPTION
## Summary

Repositioned Returned Items summary cards to the top for better visibility and usability. Added pagination to limit table rows to 20 per page for faster load times. Updated search behavior to work across the entire Returned Items dataset instead of only the visible page rows.

## Linked Issue (Required)

Closes #<ISSUE_NUMBER>

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [x] Enhancement
* [ ] Refactor
* [ ] Documentation
* [ ] Chore

## Changes Made

* Moved Returned Items summary cards (Total Returns, Total Amount, Full Returns, Partial Returns) to the top of the page
* Placed search bar and filters directly below summary cards
* Implemented pagination with 20 entries per page
* Updated search logic to query the full Returned Items dataset, not just paginated rows

## How to Test

1. Go to **Sales → Returned Items**
2. Verify summary cards are visible at the top without scrolling
3. Confirm only 20 rows are shown per page and pagination controls work
4. Search for a record that exists beyond the first page and verify it appears correctly

## CI Status

* [ ] All GitHub Actions checks are passing

## Screenshots / Logs (if applicable)

<img width="1919" height="917" alt="image" src="https://github.com/user-attachments/assets/77d95f89-8cb0-4aae-935d-bea5a15e407b" />

<img width="1919" height="917" alt="image" src="https://github.com/user-attachments/assets/cc2d280c-c74c-4f57-8f74-c3585f8ce4dc" />


## Checklist

* [x] Issue is linked and relevant
* [x] Code builds and runs locally
* [x] Self-review completed
* [x] No unused code, logs, or commented-out blocks
* [ ] Tests added or updated (if applicable)
* [ ] Docs updated (if applicable)