### PR TITLE
Fix Print Receipt button visibility on Payment In screen

### DIFF
--- a/frontend/src/pages/sales/PaymentIn.jsx
+++ b/frontend/src/pages/sales/PaymentIn.jsx
@@ -408,7 +408,7 @@ const PaymentIn = () => {
           <button
             key="print"
             onClick={handlePrint}
-            className="px-6 py-2 bg-secondary text-white rounded-lg hover:bg-gray-700"
+            className="px-6 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700"
           >
             Print Receipt
           </button>,


### PR DESCRIPTION
## Summary
Fixed an issue where the **Print Receipt** button on the **Payment In** screen was not visible by default due to low-contrast styling.  
The button is now always visible and visually consistent with the other action buttons.

## Linked Issue (Required)
Closes #145 

## Type of Change
- [x] Bug fix

## Changes Made
- Updated the styling of the Print Receipt button to ensure it is visible without hover.
- Aligned the button’s appearance with existing action buttons for consistent UX.

## How to Test
1. Go to **Sales → Payment In**
2. Observe the top-right action buttons without hovering
3. Confirm that the **Print Receipt** button is visible by default

## CI Status
- [ ] All GitHub Actions checks are passing

## Screenshots / Logs (if applicable)

## Checklist
- [x] Issue is linked and relevant
- [x] Code builds and runs locally (frontend)
- [x] Self-review completed
- [x] No unused code, logs, or commented-out blocks
- [ ] Tests added or updated (not applicable for UI styling change)
- [ ] Docs updated (not applicable)

