### PR TITLE
fix: bind tailwind dark variant to .dark class

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,6 +4,8 @@
 @tailwind components;
 @tailwind utilities;
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 /* Custom animations */
 @keyframes fade-in {
   from {


### PR DESCRIPTION
## Summary
Fixed a bug where Dark Mode styles were not applying for users with a "Light" Operating System theme, despite manually toggling the switch in the UI.

This was caused by Tailwind CSS v4 defaulting to the media strategy (prefers-color-scheme) and ignoring the class="dark" on the HTML tag because the custom variant configuration was missing in the CSS.

## Linked Issue (Required)
Closes #155 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes Made
- Added @custom-variant dark (&:where(.dark, .dark *)); to index.css to explicitly bind Tailwind's dark mode to the .dark class.

## How to Test
1. Set your Operating System (Windows/MacOS) theme to Light Mode.
2. Open the application and verify the UI is in light mode.
3. Click the theme toggle button in the app to switch to Dark Mode.
4. Verify that dark styles (colors, backgrounds) are now correctly applied (previously they remained light).

## CI Status
- [x] All GitHub Actions checks are passing

## Screenshots / Logs (if applicable)
N/A - Style configuration fix.

## Checklist
- [x] Issue is linked and relevant
- [x] Code builds and runs locally
- [x] Self-review completed
- [x] No unused code, logs, or commented-out blocks
- [ ] Tests added or updated (if applicable)
- [ ] Docs updated (if applicable)
