### PR TITLE
Fix select styling in dark and light mode

### DIFF
--- a/frontend/src/pages/sales/SalesOrderList.jsx
+++ b/frontend/src/pages/sales/SalesOrderList.jsx
@@ -172,7 +172,14 @@ const SalesOrderList = () => {
                         <select
                             value={filters.status}
                             onChange={(e) => setFilters({ ...filters, status: e.target.value })}
-                            className="w-full px-4 py-2 border border-default rounded-lg focus:ring-2 focus:ring-primary"
+                            className="
+                              w-full px-4 py-2 rounded-lg border
+                              bg-[rgb(var(--color-input))]
+                              text-[rgb(var(--color-text))]
+                              border-[rgb(var(--color-border))]
+                              focus:outline-none focus:ring-2
+                              focus:ring-[rgb(var(--color-primary))]
+                             "
                         >
                             <option value="">All Status</option>
                             <option value="Draft">Draft</option>


### PR DESCRIPTION
## What was changed
- Fixed `<select>` component styling to work correctly in both dark and light mode
- Updated select styles to use existing theme CSS variables

## Why this change
- Native select element was inheriting inconsistent colors
- Caused visual mismatch between dark and light themes

## Scope
- This PR only affects the select component UI
- No logic, API, or behavior changes

## How it was tested
- Verified select appearance in light mode
- Verified select appearance in dark mode
- Tested theme toggle and page reload
<img width="1847" height="775" alt="Screenshot 2026-01-04 121043" src="https://github.com/user-attachments/assets/8f85e17f-a074-414e-98bd-c332aeed28a6" />
<img width="1903" height="755" alt="Screenshot 2026-01-04 121027" src="https://github.com/user-attachments/assets/307faaf3-ff57-4489-8928-54947910dd80" />

