### PR TITLE
Fix/cors wildcard route crash

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -73,7 +73,6 @@ const corsOptions = {
 
 // Apply CORS and handle preflight across all routes
 app.use(cors(corsOptions));
-app.options("*", cors(corsOptions));
 
 app.use(morgan("dev"));
 


### PR DESCRIPTION
## Summary

Removed an invalid wildcard `OPTIONS` route (`app.options("/*")`) that caused the backend to crash on startup due to incompatibility with the latest `path-to-regexp`. The existing CORS middleware already handles preflight requests, so the route was redundant and harmful.

## Linked Issue (Required)

Closes #176 

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Enhancement
* [ ] Refactor
* [ ] Documentation
* [ ] Chore

## Changes Made

* Removed unsupported `app.options("/*", cors(corsOptions))` route
* Relied on `app.use(cors(corsOptions))` to handle all CORS and OPTIONS requests

## How to Test

1. Run `npm install`
2. Run `npm run dev`
3. Verify the server starts without crashing
4. Send a request that triggers a CORS preflight and confirm it succeeds

## CI Status

* [ ] All GitHub Actions checks are passing

## Screenshots / Logs (if applicable)

Startup crash log before fix showed `PathError: Missing parameter name at index 2: /*`.
After fix, server starts normally with no runtime errors.

## Checklist

* [x] Issue is linked and relevant
* [x] Code builds and runs locally
* [x] Self-review completed
* [x] No unused code, logs, or commented-out blocks
* [x] Tests added or updated (not applicable)
* [x] Docs updated (not applicable)